### PR TITLE
Nav restructure: Research + Talks & Media pages, 7-item nav, URL redi…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,26 +34,26 @@ disableKinds = ["taxonomy", "term"]
     weight = 2
 
   [[menu.main]]
-    name = "Publications"
-    url = "/publications/"
+    name = "Books"
+    url = "/books/"
     weight = 3
+
+  [[menu.main]]
+    name = "Research"
+    url = "/research/"
+    weight = 4
 
   [[menu.main]]
     name = "Talks & Media"
     url = "/talks/"
-    weight = 4
-
-  [[menu.main]]
-    name = "Funding"
-    url = "/funding/"
     weight = 5
-
-  [[menu.main]]
-    name = "CV"
-    url = "/Milligan_CV.pdf"
-    weight = 45
 
   [[menu.main]]
     name = "Contact"
     url = "/contact/"
     weight = 6
+
+  [[menu.main]]
+    name = "CV"
+    url = "/Milligan_CV.pdf"
+    weight = 45

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -2,7 +2,7 @@
 title: "About"
 ---
 
-Ian Milligan (he/him) is a Professor of History at the University of Waterloo and a Fellow of the Royal Historical Society. A leading figure in digital history and web archives, he has authored or co-authored six books — most recently _Averting the Digital Dark Age_ (Johns Hopkins, 2024) — and secured over $2.8 million in research funding across his career.
+Ian Milligan (he/him) is a Professor of History at the University of Waterloo and a Fellow of the Royal Historical Society. He has authored or co-authored six books — most recently _Averting the Digital Dark Age_ (Johns Hopkins, 2024) — and secured over $2.8 million in research funding across his career.
 
 Ian brings the same collaborative instinct to leadership as he does to research. As Associate Vice-President, Research Oversight & Integrity, he provides campus-wide leadership across research ethics, compliance, safeguarding, and research data management, co-leading the university's RDM strategy through to implementation. As PI of the [Archives Unleashed](https://archivesunleashed.org) project (2017–2023), he built and managed an interdisciplinary, multi-institution research team whose work is now offered as a [service](https://archive-it.org/arch/) by the Internet Archive.
 

--- a/content/research/_index.md
+++ b/content/research/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Research"
+aliases:
+  - /articles/
+  - /funding/
+  - /publications/
+---
+
+Ian Milligan's research explores how web archives and other born-digital traces can be used as historical evidence, and how they are transforming historical practice. His work sits at the intersection of history, archival studies, and digital infrastructure, spanning computational methods, large-scale digital preservation, and the cultural history of the internet. From 2017 to 2023 he was principal investigator of the Archives Unleashed project, now offered as a [service](https://archive-it.org/arch/) by the Internet Archive, and he is co-editor of the journal [_Internet Histories_](https://www.tandfonline.com/journals/rint20).

--- a/content/talks/_index.md
+++ b/content/talks/_index.md
@@ -1,3 +1,6 @@
 ---
 title: "Talks & Media"
+aliases:
+  - /keynotes/
+  - /media/
 ---

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -1,0 +1,79 @@
+{{ define "main" }}
+<section class="container">
+  <h1>{{ .Title }}</h1>
+
+  <div class="prose">{{ .Content }}</div>
+
+  <!-- Research Funding -->
+  <h2>Research Funding</h2>
+  {{ with site.GetPage "section" "funding" }}
+    <div class="prose">{{ .Content }}</div>
+  {{ end }}
+
+  <!-- Peer-Reviewed Articles -->
+  {{ with site.Data.articles }}
+  <h2>Peer-Reviewed Articles</h2>
+  <ul class="pub-list">
+    {{ range . }}
+    <li class="pub-item">
+      <div class="pub-title">
+        {{ if .url }}<a href="{{ .url }}" target="_blank" rel="noopener">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}
+        {{ with .note }}<span class="pub-badge">{{ . }}</span>{{ end }}
+      </div>
+      <div class="pub-meta">
+        {{ if .authors }}
+          <span class="pub-authors">{{ delimit .authors ", " }}</span> ·
+        {{ end }}
+        <em>{{ .outlet }}</em>
+        {{ with .volume }}, {{ . }}{{ end }}
+        {{ with .pages }} ({{ . }}){{ end }}
+        · <span class="pub-year">{{ .year }}</span>
+      </div>
+    </li>
+    {{ end }}
+  </ul>
+  {{ end }}
+
+  <!-- Book Chapters -->
+  {{ with site.Data.book_chapters }}
+  <h2>Book Chapters</h2>
+  <ul class="pub-list">
+    {{ range . }}
+    <li class="pub-item">
+      <div class="pub-title">{{ .title }}</div>
+      <div class="pub-meta">
+        {{ if .authors }}
+          <span class="pub-authors">{{ delimit .authors ", " }}</span> ·
+        {{ end }}
+        In <em>{{ .book }}</em>
+        {{ with .publisher }}, {{ . }}{{ end }}
+        {{ with .pages }}, pp. {{ . }}{{ end }}
+        · <span class="pub-year">{{ .year }}</span>
+      </div>
+    </li>
+    {{ end }}
+  </ul>
+  {{ end }}
+
+  <!-- Peer-Reviewed Conference Publications -->
+  {{ with site.Data.conference_papers }}
+  <h2>Peer-Reviewed Conference Publications</h2>
+  <ul class="pub-list">
+    {{ range . }}
+    <li class="pub-item">
+      <div class="pub-title">{{ .title }}</div>
+      <div class="pub-meta">
+        {{ if .authors }}
+          <span class="pub-authors">{{ delimit .authors ", " }}</span> ·
+        {{ end }}
+        <em>{{ .venue }}</em>
+        {{ with .pages }}, pp. {{ . }}{{ end }}
+        · <span class="pub-year">{{ .year }}</span>
+      </div>
+    </li>
+    {{ end }}
+  </ul>
+  {{ end }}
+
+</section>
+{{ end }}

--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -2,16 +2,17 @@
 <section class="container">
   <h1>{{ .Title }}</h1>
 
-  <!-- Keynotes (content from keynotes section) -->
-  <h2>Keynotes</h2>
+  <!-- Keynote & Invited Talks -->
+  <h2>Keynote &amp; Invited Talks</h2>
   {{ with site.GetPage "section" "keynotes" }}
     <div class="prose">{{ .Content }}</div>
   {{ end }}
 
-  <!-- Podcasts & Radio -->
+  <!-- Media Appearances -->
+  <h2>Media Appearances</h2>
   {{ with site.Data.media }}
     {{ with .podcasts }}
-      <h2>Podcasts / Radio</h2>
+      <h3>Podcasts &amp; Radio</h3>
       <ul class="link-list">
         {{ range . }}
           <li><a href="{{ .url }}" target="_blank" rel="noopener">{{ .title }}</a><span class="muted"> · {{ .outlet }} · {{ .year }}</span></li>
@@ -19,7 +20,7 @@
       </ul>
     {{ end }}
     {{ with .videos }}
-      <h2>Videos</h2>
+      <h3>Videos</h3>
       <ul class="link-list">
         {{ range . }}
           <li><a href="{{ .url }}" target="_blank" rel="noopener">{{ .title }}</a><span class="muted"> · {{ .outlet }} · {{ .year }}</span></li>


### PR DESCRIPTION
…rects

- Fix about page: remove 'A leading figure' phrase from opening
- Create /research/ page combining grants, articles, book chapters, conference papers with aliases at /articles/, /funding/, /publications/
- Update /talks/ page aliases to /keynotes/ and /media/
- Update talks layout with cleaner section headings
- Update config.toml nav to 7 items: Home | About | Books | Research | Talks & Media | Contact | CV