### PR TITLE
Fix hero title overflow on narrow mobile viewports

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -179,11 +179,12 @@ a:hover {
 }
 .hero-title {
   font-family: var(--font-heading);
-  font-size: 2.75rem;
+  font-size: clamp(1.75rem, 7vw, 2.75rem);
   letter-spacing: 0.02em;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.15;
+  overflow-wrap: break-word;
 }
 .hero-title .postnominal {
   font-size: 0.42em;


### PR DESCRIPTION
Replace the fixed 2.75rem hero title font-size with clamp(1.75rem, 7vw, 2.75rem) so "IAN MILLIGAN,FRHistS" no longer overflows past the right edge on iPhone-sized viewports. The nowrap postnominal abbreviation was running off the page at 375-393px widths. Desktop sizing is unchanged.