### PR TITLE
Add Goodreads links and split Publisher/Open Access buttons

### DIFF
--- a/data/books.yml
+++ b/data/books.yml
@@ -4,19 +4,27 @@
   publisher: "Johns Hopkins University Press"
   cover: "images/books/averting.jpg"  # drop the cover image here
   links:
-    - label: "Publisher (OPEN ACCESS)"
+    - label: "Publisher"
       url: "https://www.press.jhu.edu/books/title/53671/averting-digital-dark-age"
+    - label: "Open Access"
+      url: "https://muse.jhu.edu/book/123276"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/208283384-averting-the-digital-dark-age"
     - label: "Amazon.com"
       url: "https://www.amazon.com/Averting-Digital-Dark-Age-Technologists/dp/1421450135/ref=sr_1_1?crid=SRN391KVJFEE&dib=eyJ2IjoiMSJ9.LcAgdqXFokdKYmGwCxeOJQ.JJ0R690P8RQWJn8OmPVlwpqiVVfBIwRz8w9MQmVHNaE&dib_tag=se&keywords=%22Averting+the+digital+dark+AGe%22&qid=1732397007&sprefix=averting+the+digital+dark+age+%2Caps%2C111&sr=8-1"
     - label: "Amazon.ca"
-      url: https://www.amazon.ca/Averting-Digital-Dark-Age-Technologists/dp/1421450135    
+      url: https://www.amazon.ca/Averting-Digital-Dark-Age-Technologists/dp/1421450135
 - title: "The Transformation of Historical Research in the Digital Age"
   year: 2022
   publisher: "Cambridge University Press"
   cover: "images/books/transformation.png"
   links:
-    - label: "Publisher (OPEN ACCESS)"
+    - label: "Publisher"
       url: "https://www.cambridge.org/core/elements/transformation-of-historical-research-in-the-digital-age/30DFBEAA3B753370946B7A98045CFEF4"
+    - label: "Open Access"
+      url: "https://www.cambridge.org/core/services/aop-cambridge-core/content/view/30DFBEAA3B753370946B7A98045CFEF4/9781009012522AR.pdf/the-transformation-of-historical-research-in-the-digital-age.pdf"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/61234248-the-transformation-of-historical-research-in-the-digital-age"
     - label: "Amazon.ca"
       url: "https://www.amazon.ca/Transformation-Historical-Research-Digital-Age/dp/1009012525/ref=sr_1_1?crid=2Z4F0T0EP5QRW&keywords=transformation+of+historical+research&qid=1659966798&sprefix=transformation+of+historical+research%2Caps%2C60&sr=8-1"
 - title: "History in the Age of Abundance"
@@ -27,6 +35,8 @@
   links:
     - label: "MQUP"
       url: "https://www.mqup.ca/history-in-the-age-of-abundance--products-9780773556973.php?page_id=46&"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/42682653-history-in-the-age-of-abundance"
     - label: "Amazon.ca"
       url: "https://www.amazon.ca/History-Age-Abundance-Transforming-Historical/dp/0773556974"
 - title: "SAGE Handbook of Web History (ed.)"
@@ -37,6 +47,8 @@
   links:
     - label: "SAGE"
       url: "http://uk.sagepub.com/en-gb/eur/the-sage-handbook-of-web-history/book252251"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/39970862-the-sage-handbook-of-web-history"
     - label: "Amazon.ca"
       url: "https://www.amazon.ca/SAGE-HANDBOOK-WEB-HISTO-RY/dp/1473980054"
 - title: "Exploring Big Historical Data: The Historian’s Macroscope, 2nd Edition"
@@ -47,6 +59,8 @@
   links:
     - label: "World Scientific"
       url: "https://www.worldscientific.com/worldscibooks/10.1142/12435?srsltid=AfmBOopskOO2_S-ulicP_vKYuDRP3VYtNrBHUT3kMQ7xaSRw5wLAt6co#t=aboutBook"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/63037087-exploring-big-historical-data"
 - title: "Rebel Youth"
   subtitle: 1960s Labour Unrest, Young Workers, and New Leftists in English Canada
   year: 2014
@@ -55,3 +69,5 @@
   links:
     - label: "UBC Press"
       url: "https://www.ubcpress.ca/rebel-youth"
+    - label: "Goodreads"
+      url: "https://www.goodreads.com/book/show/19147910-rebel-youth"


### PR DESCRIPTION
## Summary
- Adds a "Goodreads" link to every book in `data/books.yml` (6 books total).
- Splits the combined "Publisher (OPEN ACCESS)" button into two separate buttons — "Publisher" (publisher's catalog page) and "Open Access" (direct link to the free full text) — for the two open-access titles:
  - *Averting the Digital Dark Age* → Open Access points to Project MUSE (`muse.jhu.edu/book/123276`).
  - *The Transformation of Historical Research in the Digital Age* → Open Access points to the Cambridge PDF.

## Why
The previous "Publisher (OPEN ACCESS)" label conflated two different destinations (the publisher's marketing page and the free full text). Splitting them lets readers go straight to whichever they want, and adding Goodreads gives a consistent third place for readers to find reviews / ratings across the whole backlist.

## Notes for reviewer
- No layout changes needed — `layouts/partials/books-grid.html` already iterates over `links` and renders each `{label, url}` pair, so adding new entries just works.
- Hugo build runs clean locally and the rendered HTML shows the buttons in the expected order on both the hero book and the backlist grid.
- Goodreads URLs were looked up via web search; the *Macroscope* link points to the paperback 2nd edition (World Scientific, March 2022) to match the edition listed on the page.

## Test plan
- [ ] `hugo server` and confirm the books page renders the new buttons in the right order.
- [ ] Click each new Goodreads link and verify it lands on the correct book.
- [ ] Click the new "Open Access" buttons on *Averting* and *Transformation* and confirm they load the free full text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)