### PR TITLE
Style Open Access buttons as filled accent variant

### DIFF
--- a/layouts/partials/books-grid.html
+++ b/layouts/partials/books-grid.html
@@ -17,7 +17,7 @@
       {{ with $first.links }}
         <div class="links">
           {{ range . }}
-            <a href="{{ .url }}" target="_blank" rel="noopener">{{ .label }}</a>
+            <a href="{{ .url }}" target="_blank" rel="noopener"{{ if eq .label "Open Access" }} class="featured"{{ end }}>{{ .label }}</a>
           {{ end }}
         </div>
       {{ end }}
@@ -45,7 +45,7 @@
           {{ with $book.links }}
             <div class="links">
               {{ range . }}
-                <a href="{{ .url }}" target="_blank" rel="noopener">{{ .label }}</a>
+                <a href="{{ .url }}" target="_blank" rel="noopener"{{ if eq .label "Open Access" }} class="featured"{{ end }}>{{ .label }}</a>
               {{ end }}
             </div>
           {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -445,6 +445,18 @@ hr, .section-divider {
   color: #FFFFFF;
   border-bottom: none;
 }
+.links a.featured {
+  background-color: var(--accent);
+  color: #FFFFFF;
+}
+.links a.featured::before {
+  content: "★ ";
+  font-size: 0.9em;
+}
+.links a.featured:hover {
+  background-color: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
 
 /* === Publication Lists =========================================== */
 .link-list { list-style: none; padding: 0; margin: 1rem 0; display: grid; gap: 0.5rem; }


### PR DESCRIPTION
## Summary
- Make the "Open Access" buttons on the books page visually pop against the other link buttons by giving them a filled accent-color background (vs. the outlined style everyone else uses) and a leading ★ glyph.
- Affects the two books that have an Open Access link: *Averting the Digital Dark Age* (hero) and *The Transformation of Historical Research in the Digital Age* (backlist).

## Why
Of all the links on a book entry — Publisher, Goodreads, Amazon, etc. — Open Access is the most consequential: it's where readers go to actually read the book for free. Previously it looked identical to every other outlined link button. Promoting it to a filled primary-button style gives it visual priority in the row without restructuring the layout.

## Implementation
- `layouts/partials/books-grid.html`: when a link's label is `"Open Access"`, render `<a class="featured">`. Applied in both the hero block and the backlist card.
- `static/css/main.css`: new `.links a.featured` rule — solid `--accent` background, white text, ★ prefix via `::before`, darker `--accent-hover` on hover.

## Test plan
- [ ] Visit `/` and confirm the Open Access button on *Averting the Digital Dark Age* renders as a filled green button with a ★ prefix, while Publisher / Goodreads / Amazon remain outlined.
- [ ] Visit `/books/` and confirm the same styling appears on *Transformation of Historical Research*'s Open Access button in the backlist grid.
- [ ] Hover the featured button and confirm it darkens to `--accent-hover` (not back to the outlined state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)