### PR TITLE
Nudge Netlify to rebuild

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 # netlify.toml
+# Rebuild nudge: 2026-05-20
 
 [build]
   command = "hugo --gc --minify -b $URL"


### PR DESCRIPTION
## Summary
One-line comment added to `netlify.toml` so this commit will trigger a fresh Netlify deploy.

## Why
PR #11 was merged ~18 hours ago as `b809d07`, but the live site is still serving the pre-#11 CSS and HTML — `.featured` is absent from both `/css/main.css` and the rendered anchor tags. Netlify either never picked up the merge or the build failed silently (Netlify doesn't report status to GitHub for this repo, so I can't see which from here).

Merging this PR should kick off a clean build that finally publishes the Open Access button styling.

## Test plan
- [ ] Merge.
- [ ] Wait for Netlify build to finish.
- [ ] `curl -s https://www.ianmilligan.ca/css/main.css | grep featured` returns the `.links a.featured` rules.
- [ ] `curl -sL https://www.ianmilligan.ca/books/ | grep "Open Access"` shows `class="featured"` on the anchor.
- [ ] Visit the homepage — the *Averting* Open Access button is filled green with a ★.

If this PR merges and the site **still** shows pre-#11 content, the Netlify build is failing — check the Deploys tab in the Netlify dashboard for an error log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)