### PR TITLE
Add 2026 keynote at University of Lille

### DIFF
--- a/content/keynotes/_index.md
+++ b/content/keynotes/_index.md
@@ -2,6 +2,9 @@
 title: "Keynotes"
 ---
 
+## 2026
+- **The Legibility of Absence: From the Finding Aid to the Language Model** — *Digitisation of scholarly knowledge through the prism of research practices*, University of Lille, Villeneuve-d'Ascq, France, **May 2026**.
+
 ## 2025
 - **Exploring Digital Terror: Using the September 11 Digital Archive for Historical Research** — *Real-Time History: Engaging with Living Archives and Temporal Multiplicities*, Washington, DC, **March 2025**.
 


### PR DESCRIPTION
## Summary
- Adds a new 2026 section to the Keynotes page with "The Legibility of Absence: From the Finding Aid to the Language Model," delivered at *Digitisation of scholarly knowledge through the prism of research practices*, University of Lille, Villeneuve-d'Ascq, France, May 2026.

## Test plan
- [ ] Verify the new entry renders under a 2026 heading at the top of the Keynotes page on the Netlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)