### PR TITLE
Switch typography to EB Garamond

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{{ .Site.Params.description }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Source+Sans+3:wght@300;400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Inconsolata:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
 </head>
 <body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,5 +13,7 @@
     </p>
   </section>
 
+  <hr>
+
   {{ partial "books-grid.html" . }}
 {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -31,8 +31,9 @@
   --maxw: 1000px;
 
   /* Fonts */
-  --font-heading: 'Libre Baskerville', Georgia, serif;
-  --font-body:    'Source Sans 3', 'Source Sans Pro', -apple-system, sans-serif;
+  --font-heading: 'EB Garamond', Georgia, serif;
+  --font-body:    'EB Garamond', Georgia, serif;
+  --font-mono:    'Inconsolata', ui-monospace, 'SFMono-Regular', monospace;
 }
 
 /* === Reset ======================================================= */
@@ -42,20 +43,21 @@ html, body { margin: 0; padding: 0; }
 /* === Base ======================================================== */
 body {
   font-family: var(--font-body);
-  font-size: 17px;
-  line-height: 1.65;
+  font-size: 19px;
+  line-height: 1.6;
   color: var(--text-primary);
   background-color: var(--bg-primary);
+  font-variant-numeric: oldstyle-nums;
 }
 
 .container { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem; }
-.prose p   { max-width: 65ch; }
+.prose p   { max-width: 65ch; hyphens: auto; -webkit-hyphens: auto; }
 .muted     { color: var(--text-secondary); }
 
 /* === Typography ================================================== */
 h1, h2, h3 {
   font-family: var(--font-heading);
-  font-weight: 700;
+  font-weight: 600;
   color: var(--text-primary);
   letter-spacing: 0.01em;
 }
@@ -96,7 +98,7 @@ a:hover {
 }
 .brand {
   font-family: var(--font-heading);
-  font-weight: 700;
+  font-weight: 600;
   font-size: 1.05rem;
   text-decoration: none;
   border-bottom: none;
@@ -180,8 +182,8 @@ a:hover {
 .hero-title {
   font-family: var(--font-heading);
   font-size: clamp(1.75rem, 7vw, 2.75rem);
-  letter-spacing: 0.02em;
-  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-weight: 600;
   color: var(--text-primary);
   line-height: 1.15;
   overflow-wrap: break-word;
@@ -196,6 +198,7 @@ a:hover {
 }
 .hero-kicker {
   font-size: 1.15rem;
+  font-style: italic;
   color: var(--text-secondary);
   margin: 0.75rem 0 0;
 }
@@ -322,10 +325,20 @@ blockquote cite a:hover {
 /* === Section Dividers ============================================ */
 hr, .section-divider {
   border: none;
-  height: 1px;
-  background-color: var(--border-light);
-  margin: 3rem auto;
-  max-width: 120px;
+  background: none;
+  height: auto;
+  margin: 2.5rem auto;
+  max-width: none;
+  text-align: center;
+  color: var(--text-light);
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  line-height: 1;
+  overflow: visible;
+}
+hr::after,
+.section-divider::after {
+  content: "\2766"; /* ❦ */
 }
 
 /* === Books ======================================================= */
@@ -352,14 +365,15 @@ hr, .section-divider {
   display: block;
 }
 .book-hero-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-variant-caps: small-caps;
+  letter-spacing: 0.04em;
   color: var(--text-secondary);
 }
 .book-hero-title {
   font-family: var(--font-heading);
+  font-weight: 600;
   font-size: 1.5rem;
   margin: 0.25rem 0;
   color: var(--text-primary);
@@ -372,9 +386,9 @@ hr, .section-divider {
 .backlist-heading {
   font-family: var(--font-body);
   color: var(--text-secondary);
-  font-size: 0.875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 1.1rem;
+  font-variant-caps: small-caps;
+  letter-spacing: 0.04em;
   margin: 1.5rem 0 0.75rem;
   font-weight: 600;
 }
@@ -424,6 +438,7 @@ hr, .section-divider {
 .card-body { padding: 1rem 1.25rem 1.25rem; }
 .card-title {
   font-family: var(--font-heading);
+  font-weight: 600;
   margin: 0.25rem 0;
   font-size: 1.05rem;
   color: var(--text-primary);
@@ -511,6 +526,7 @@ hr, .section-divider {
 }
 .footer-grid h4 {
   font-family: var(--font-heading);
+  font-weight: 600;
   color: var(--text-primary);
   margin: 0.25rem 0 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Replace Libre Baskerville + Source Sans with a single warm serif (EB Garamond) used for both headings and body
- Tune body to 19px / 1.6 line-height and drop heading weights to 600 to suit Garamond's smaller x-height
- Add booky refinements: old-style figures site-wide, true small caps for "Latest Book" / "Earlier Books" labels, hyphenation on prose paragraphs, italic hero kicker, and a fleuron divider between About and Books on the homepage

## Test plan
- [ ] Homepage hero renders in EB Garamond at weight 600 (not falling back to Georgia)
- [ ] About page body reads as Garamond at 19px and hyphenates on mobile (~375px)
- [ ] Pull-quote on the homepage uses Garamond italic
- [ ] Book card titles render at weight 600
- [ ] "Latest Book" / "Earlier Books" appear as true small caps
- [ ] Year numerals (2024, 2025, etc.) render as old-style figures
- [ ] Fleuron (❦) shows between About and Books on the homepage
- [ ] No console errors; font resources load from Google Fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)