### PR TITLE
Add 2026 GLOW-Ready keynote on AI and archival absence

### DIFF
--- a/content/keynotes/_index.md
+++ b/content/keynotes/_index.md
@@ -3,6 +3,7 @@ title: "Keynotes"
 ---
 
 ## 2026
+- **What the AI Won’t Tell You: Absence and the Architecture of Trust** — *GLOW-Ready: Getting Government Archives GenAI-Ready*, LUSTRE Network, online, **June 2026**.
 - **The Legibility of Absence: From the Finding Aid to the Language Model** — *Digitisation of Scholarly Knowledge Through the Prism of Research Practices*, University of Lille, Villeneuve-d’Ascq, France, **May 2026**.
 
 ## 2025


### PR DESCRIPTION
Adds "What the AI Won't Tell You: Absence and the Architecture of Trust," delivered at the LUSTRE Network's GLOW-Ready (Getting Government Archives GenAI-Ready) online workshop, June 2026.

Placed at the top of the 2026 keynotes section to keep reverse-chronological order.

Source: https://lustre-network.net/event/glow-ready-getting-government-archives-genai-ready-workshop-2/

🤖 Generated with [Claude Code](https://claude.com/claude-code)